### PR TITLE
refactor: ntex version and some clippy warning

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
           - nightly
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,13 +54,11 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows
-          Copy-Item C:\vcpkg\installed\x64-windows\bin\libcrypto-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libcrypto.dll
-          Copy-Item C:\vcpkg\installed\x64-windows\bin\libssl-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libssl.dll
-          Get-ChildItem C:\vcpkg\installed\x64-windows\bin
-          Get-ChildItem C:\vcpkg\installed\x64-windows\lib
 
       - name: Run tests
         uses: actions-rs/cargo@v1
+        env:
+          OPENSSL_ROOT_DIR: D:\vcpkg\installed\x64-windows-static-md
         with:
           command: test
           args: --all --all-features -- --nocapture

--- a/ntex-cors/Cargo.toml
+++ b/ntex-cors/Cargo.toml
@@ -16,9 +16,9 @@ name = "ntex_cors"
 path = "src/lib.rs"
 
 [dependencies]
-ntex = "0.6.0-beta.0"
+ntex = "0.6.5"
 derive_more = "0.99"
 futures = "0.3"
 
 [dev-dependencies]
-ntex = { version = "0.6.0-beta.0", features=["tokio"] }
+ntex = { version = "0.6.5", features=["tokio"] }

--- a/ntex-cors/src/lib.rs
+++ b/ntex-cors/src/lib.rs
@@ -536,7 +536,7 @@ impl Inner {
                     AllOrSome::Some(ref allowed_origins) => allowed_origins
                         .get(origin)
                         .map(|_| ())
-                        .ok_or_else(|| CorsError::OriginNotAllowed),
+                        .ok_or(CorsError::OriginNotAllowed),
                 };
             }
             Err(CorsError::BadOrigin)
@@ -553,10 +553,8 @@ impl Inner {
             AllOrSome::All => {
                 if self.send_wildcard {
                     Some(HeaderValue::from_static("*"))
-                } else if let Some(origin) = headers.get(&header::ORIGIN) {
-                    Some(origin.clone())
                 } else {
-                    None
+                    headers.get(&header::ORIGIN).cloned()
                 }
             }
             AllOrSome::Some(ref origins) => {
@@ -582,7 +580,7 @@ impl Inner {
                         .methods
                         .get(&method)
                         .map(|_| ())
-                        .ok_or_else(|| CorsError::MethodNotAllowed);
+                        .ok_or(CorsError::MethodNotAllowed);
                 }
             }
             Err(CorsError::BadRequestMethod)
@@ -641,10 +639,8 @@ impl Inner {
                     )
                     .unwrap(),
                 )
-            } else if let Some(hdr) = req.headers.get(&header::ACCESS_CONTROL_REQUEST_HEADERS) {
-                Some(hdr.clone())
             } else {
-                None
+                req.headers.get(&header::ACCESS_CONTROL_REQUEST_HEADERS).cloned()
             };
 
             let res = HttpResponse::Ok()

--- a/ntex-files/Cargo.toml
+++ b/ntex-files/Cargo.toml
@@ -18,7 +18,7 @@ name = "ntex_files"
 path = "src/lib.rs"
 
 [dependencies]
-ntex = "0.6.0-beta.0"
+ntex = "0.6.5"
 ntex-http = "0.1.8"
 bitflags = "1.3"
 futures = "0.3"
@@ -32,4 +32,4 @@ percent-encoding = "2.1"
 v_htmlescape = "0.14.1"
 
 [dev-dependencies]
-ntex = { version = "0.6.0-beta.0", features=["tokio", "openssl", "compress"] }
+ntex = { version = "0.6.5", features=["tokio", "openssl", "compress"] }

--- a/ntex-identity/Cargo.toml
+++ b/ntex-identity/Cargo.toml
@@ -21,7 +21,7 @@ default = ["cookie-policy"]
 cookie-policy = ["cookie/secure", "ntex/cookie"]
 
 [dependencies]
-ntex = "0.6.0-beta.0"
+ntex = "0.6.5"
 futures = "0.3"
 serde = "1.0"
 serde_json = "1.0"
@@ -30,4 +30,4 @@ cookie = { version = "0.17", features = ["private"] }
 time = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-ntex = { version = "0.6.0-beta.0", features=["tokio"] }
+ntex = { version = "0.6.5", features=["tokio"] }

--- a/ntex-multipart/Cargo.toml
+++ b/ntex-multipart/Cargo.toml
@@ -16,7 +16,7 @@ name = "ntex_multipart"
 path = "src/lib.rs"
 
 [dependencies]
-ntex = "0.6.0-beta.0"
+ntex = "0.6.5"
 derive_more = "0.99"
 httparse = "1.3"
 futures = "0.3"
@@ -25,4 +25,4 @@ mime = "0.3"
 twoway = "0.2"
 
 [dev-dependencies]
-ntex = { version = "0.6.0-beta.0", features=["tokio"] }
+ntex = { version = "0.6.5", features=["tokio"] }

--- a/ntex-multipart/src/server.rs
+++ b/ntex-multipart/src/server.rs
@@ -261,10 +261,8 @@ impl InnerMultipart {
                 match self.state {
                     // read until first boundary
                     InnerState::FirstBoundary => {
-                        match InnerMultipart::skip_until_boundary(
-                            &mut *payload,
-                            &self.boundary,
-                        )? {
+                        match InnerMultipart::skip_until_boundary(&mut payload, &self.boundary)?
+                        {
                             Some(eof) => {
                                 if eof {
                                     self.state = InnerState::Eof;
@@ -278,7 +276,7 @@ impl InnerMultipart {
                     }
                     // read boundary
                     InnerState::Boundary => {
-                        match InnerMultipart::read_boundary(&mut *payload, &self.boundary)? {
+                        match InnerMultipart::read_boundary(&mut payload, &self.boundary)? {
                             None => return Poll::Pending,
                             Some(eof) => {
                                 if eof {
@@ -295,7 +293,7 @@ impl InnerMultipart {
 
                 // read field headers for next field
                 if self.state == InnerState::Headers {
-                    if let Some(headers) = InnerMultipart::read_headers(&mut *payload)? {
+                    if let Some(headers) = InnerMultipart::read_headers(&mut payload)? {
                         self.state = InnerState::Boundary;
                         headers
                     } else {
@@ -547,9 +545,9 @@ impl InnerField {
         let result = if let Some(mut payload) = self.payload.as_ref().unwrap().get_mut(s) {
             if !self.eof {
                 let res = if let Some(ref mut len) = self.length {
-                    InnerField::read_len(&mut *payload, len)
+                    InnerField::read_len(&mut payload, len)
                 } else {
-                    InnerField::read_stream(&mut *payload, &self.boundary)
+                    InnerField::read_stream(&mut payload, &self.boundary)
                 };
 
                 match res {
@@ -810,7 +808,7 @@ mod tests {
 
     impl SlowStream {
         fn new(bytes: Bytes) -> SlowStream {
-            return SlowStream { bytes, pos: 0, ready: false };
+            SlowStream { bytes, pos: 0, ready: false }
         }
     }
 

--- a/ntex-session/Cargo.toml
+++ b/ntex-session/Cargo.toml
@@ -22,7 +22,7 @@ default = ["cookie-session"]
 cookie-session = ["cookie/secure", "ntex/cookie"]
 
 [dependencies]
-ntex = "0.6.0-beta.0"
+ntex = "0.6.5"
 cookie = "0.17"
 derive_more = "0.99"
 futures = "0.3"
@@ -31,4 +31,4 @@ serde_json = "1.0"
 time = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-ntex = { version = "0.6.0-beta.0", features=["tokio"] }
+ntex = { version = "0.6.5", features=["tokio"] }

--- a/ntex-session/src/cookie.rs
+++ b/ntex-session/src/cookie.rs
@@ -378,7 +378,7 @@ mod tests {
 
         let request = test::TestRequest::get().to_request();
         let response = app.call(request).await.unwrap();
-        assert!(response.response().cookies().find(|c| c.name() == "ntex-session").is_some());
+        assert!(response.response().cookies().any(|c| c.name() == "ntex-session"));
     }
 
     #[ntex::test]
@@ -395,7 +395,7 @@ mod tests {
 
         let request = test::TestRequest::get().to_request();
         let response = app.call(request).await.unwrap();
-        assert!(response.response().cookies().find(|c| c.name() == "ntex-session").is_some());
+        assert!(response.response().cookies().any(|c| c.name() == "ntex-session"));
     }
 
     #[ntex::test]
@@ -412,7 +412,7 @@ mod tests {
 
         let request = test::TestRequest::get().to_request();
         let response = app.call(request).await.unwrap();
-        assert!(response.response().cookies().find(|c| c.name() == "ntex-session").is_some());
+        assert!(response.response().cookies().any(|c| c.name() == "ntex-session"));
     }
 
     #[ntex::test]


### PR DESCRIPTION
Hey i started to investigate a version problem when using `ntex-files` and it's seems that `hyperx` is [unmaintained](https://github.com/dekellum/hyperx/issues/39).
I could find a workaround by removing one dependency that my project use it came from `Url` but it could be problematic in some other cases. Should we fork `hyperx` maybe ?

Since i was inside the code i upgraded the version to ntex 0.6.5 and did fix some clippy warning along the way