### PR TITLE
chore: update ntex-cors doc to use http::Method instead of &str

### DIFF
--- a/ntex-cors/src/lib.rs
+++ b/ntex-cors/src/lib.rs
@@ -26,7 +26,7 @@
 //!         .wrap(
 //!             Cors::new() // <- Construct CORS middleware builder
 //!               .allowed_origin("https://www.rust-lang.org/")
-//!               .allowed_methods(vec!["GET", "POST"])
+//!               .allowed_methods(vec![http::Method::GET, http::Method::POST])
 //!               .allowed_headers(vec![http::header::AUTHORIZATION, http::header::ACCEPT])
 //!               .allowed_header(http::header::CONTENT_TYPE)
 //!               .max_age(3600)
@@ -259,7 +259,18 @@ impl Cors {
     /// This is the `list of methods` in the
     /// [Resource Processing Model](https://www.w3.org/TR/cors/#resource-processing-model).
     ///
-    /// Defaults to `[GET, HEAD, POST, OPTIONS, PUT, PATCH, DELETE]`
+    /// You can use either `&str` (e.g. `"GET"`) or directly use the [`http::Method`] enum
+    /// (e.g. `http::Method::GET`). Using [`http::Method`] is recommended for better type safety
+    /// and to avoid runtime errors due to typos.
+    ///
+    /// # Example
+    /// ```rust
+    /// use ntex::http::Method;
+    ///
+    /// cors.allowed_methods(vec![Method::GET, Method::POST]);
+    /// ```
+    ///
+    /// The default is `[GET, HEAD, POST, OPTIONS, PUT, PATCH, DELETE]`.
     pub fn allowed_methods<U, M>(mut self, methods: U) -> Self
     where
         U: IntoIterator<Item = M>,


### PR DESCRIPTION
This PR improves the documentation for allowed_methods in ntex-cors.

The current doc example uses vector of &str (e.g. `vec!["GET", "POST"]`), which is valid but might lead to runtime errors due to typos or unsupported values.

This update suggests using `http::Method` enum instead, which improves type safety and better aligns with idiomatic Rust practices.

Why?
- Prevent possible runtime errors
- Improve developer experience
- Promote usage of enums over raw strings

