### PR TITLE
Fix Cors::allowed_origin to set "*" as AllOrSome::All

### DIFF
--- a/ntex-cors/src/lib.rs
+++ b/ntex-cors/src/lib.rs
@@ -1106,7 +1106,7 @@ mod tests {
     }
 
     #[ntex::test]
-    async fn test_allowed_origin_to_all() {
+    async fn test_set_allowed_origin_to_all() {
         let cors = Cors::new().allowed_origin("*").finish().create(test::ok_service()).into();
 
         let req = TestRequest::with_header("Origin", "https://www.example.com")

--- a/ntex-cors/src/lib.rs
+++ b/ntex-cors/src/lib.rs
@@ -238,6 +238,11 @@ impl Cors {
         if let Some(cors) = cors(&mut self.cors, &self.error) {
             match Uri::try_from(origin) {
                 Ok(_) => {
+                    // If the origin is "*", set the origins to `All`
+                    if origin.trim() == "*" {
+                        cors.origins = AllOrSome::All;
+                        return self;
+                    }
                     if cors.origins.is_all() {
                         cors.origins = AllOrSome::Some(HashSet::new());
                     }
@@ -1098,5 +1103,17 @@ mod tests {
             &b"https://example.org"[..],
             resp.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN).unwrap().as_bytes()
         );
+    }
+
+    #[ntex::test]
+    async fn test_allowed_origin_to_all() {
+        let cors = Cors::new().allowed_origin("*").finish().create(test::ok_service()).into();
+
+        let req = TestRequest::with_header("Origin", "https://www.example.com")
+            .method(Method::GET)
+            .to_srv_request();
+
+        let resp = test::call_service(&cors, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
Currently, calling `.allowed_origin("*")` has no effect, and the origin is not interpreted as wildcard. 

This patch handles "*" explicitly by setting `cors.origins = AllOrSome::All`.

This fixes CORS behavior in browser-based environments such as React/Axios where wildcard origin is expected to allow cross-origin access.